### PR TITLE
VAI Fixes

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -74,3 +74,4 @@ tsv-possessive.txt
 tsv-posswithm.txt
 tsv-singulars.txt
 tsv-syncopated.txt
+vai.txt

--- a/src/nish-template.txt
+++ b/src/nish-template.txt
@@ -34,8 +34,8 @@ LEXICON VAI_Vowel_Final_Suffixes
 
 ! +Pres from Biigtigong tables implicit here 
 LEXICON VAI_Vowel_Final_Indep_Suffixes
-	+1P+Sg+Indic:0		# ;		! Biigtigong verb chart VAI sheet (1a)
-	+2P+Sg+Indic:0		# ;
+	+1P+Sg+Indic:@		# ;		! Biigtigong verb chart VAI sheet (1a)
+	+2P+Sg+Indic:@		# ;		! "@" here means drop preceding short vowel
 	+3P+Sg+Indic:0		# ;
 	+3P+Obv+Indic:wan	# ;
 	+1P+Pl+Indic:min		# ;

--- a/src/nish-template.txt
+++ b/src/nish-template.txt
@@ -82,18 +82,18 @@ LEXICON VAI_Vowel_Final_Indep_Suffixes
 	+2P+Pl+Neg+Pret:siimwaaban		# ;
 	+3P+Pl+Neg+Pret:siibaniig		# ;
 	+Imp+Neg+Pret:siimiban			# ;
-	+1P+Sg+Neg+Dub:siinaadig		# ;		! Biigtigong verb chart VAI sheet (3b)
-	+2P+Sg+Neg+Dub:siinaadig		# ;
-	+3P+Sg+Neg+Dub:siidig		# ;
-	+3P+Obv+Neg+Dub:siidigenan		# ;
-	+1P+Pl+Neg+Dub:siiminaadig		# ;
-	+1P+Ex+Neg+Dub:siiminaadig		# ;
-	+2P+Pl+Neg+Dub:siiwaadig		# ;
-	+3P+Pl+Neg+Dub:siidigenag		# ;
-	+Imp+Neg+Dub:siimidig			# ;
+	+1P+Sg+Neg+Dub:siinaadog		# ;		! Biigtigong verb chart VAI sheet (3b)
+	+2P+Sg+Neg+Dub:siinaadog		# ;
+	+3P+Sg+Neg+Dub:siidog		# ;
+	+3P+Obv+Neg+Dub:siidogwenan		# ;
+	+1P+Pl+Neg+Dub:siiminaadog		# ;
+	+1P+Ex+Neg+Dub:siiminaadog		# ;
+	+2P+Pl+Neg+Dub:siiwaadog		# ;
+	+3P+Pl+Neg+Dub:siidogwenag		# ;
+	+Imp+Neg+Dub:siimwaadog			# ;
 	+3P+Sg+Neg+PretDub:siigoban		# ;		! Biigtigong verb chart VAI sheet (4b)
 	+3P+Obv+Neg+PretDub:siinigoban		# ;
-	+3P+Pl+Neg+PretDub:siiwaagoban		# ;
+	+3P+Pl+Neg+PretDub:siigwaaban		# ;
 
 LEXICON VAI_Vowel_Final_Conj_Suffixes
 

--- a/src/nish.fst
+++ b/src/nish.fst
@@ -1,6 +1,6 @@
 read lexc nish.txt
 define Lexicon;
-define DisallowIntermediateTags ~[$[ "+NAPl" | "+NIPl" | "+NASg" | "+NISg" | "+Poss" ]];
+define DisallowIntermediateTags ~[$[ "+NAPl" | "+NIPl" | "+NASg" | "+NISg" | "+Poss" | "+1P" | "+2P" | "+3P" | "+Ex" | "+Imp" ]];
 define AnimatePlural [ "+Pl" -> "+NAPl" || "+NA" ?* _ .#. ];
 define InanimatePlural [ "+Pl" -> "+NIPl" || "+NI" ?* _ .#. ];
 define AnimateSingular [ "+Sg" -> "+NASg" || "+NA" ?* _ .#. ];
@@ -51,7 +51,9 @@ define LeniteQuasiDim [ z e n s "^" i s -> z h e n z h i s ];  ! as in kwezens -
 define SingularCleanup [ "^" [ w | W | y ] -> 0 || _ .#. ];
 define classVICleanup [ "^" A -> 0 ];
 define dropFinalCluster [ [ d | m | n | n d | t ] "~" n z -> n z || [ a | e | i | o ] _ ];
+define keepFinalLongVowel [ "@" -> 0 || [ a a | i i | o o ] _ .#. ];
+define dropFinalShortVowel [ [ a | i | o ] "@" -> 0 || _ .#. ];
 define Cleanup [ "^" -> 0, "@" -> 0 ];
-define Morph [ DisallowIntermediateTags .o. LongDistanceDependencies .o. Lexicon .o. dropFinalCluster .o. PossPrefixRules .o. PluralRules .o. ClassVFinalI .o. ClassVOther .o. ConOrDimRules .o. ShortAConOrDim .o. LeniteQuasiDim .o. ClassVIDropY .o. PejRules .o. LocRules .o. PossThmRules .o. ShortALocOrPoss .o. classVICleanup .o. SingularCleanup .o. Cleanup .o. @"syncopate.bin" ];
+define Morph [ DisallowIntermediateTags .o. LongDistanceDependencies .o. Lexicon .o. dropFinalCluster .o. keepFinalLongVowel .o. dropFinalShortVowel .o. PossPrefixRules .o. PluralRules .o. ClassVFinalI .o. ClassVOther .o. ConOrDimRules .o. ShortAConOrDim .o. LeniteQuasiDim .o. ClassVIDropY .o. PejRules .o. LocRules .o. PossThmRules .o. ShortALocOrPoss .o. classVICleanup .o. SingularCleanup .o. Cleanup .o. @"syncopate.bin" ];
 push Morph
 save stack nish.bin

--- a/src/nish.fst
+++ b/src/nish.fst
@@ -24,8 +24,9 @@ define 1pActor [ "+Indep" -> "+Indep" "+1P" "+Pl" || .#. "1P+" "Pl+" ?+ _ ];
 define 21Actor [ "+Indep" -> "+Indep" "+1P" "+Ex" || .#. "1P+" "Ex+" ?+ _ ]; 
 define 2pActor [ "+Indep" -> "+Indep" "+2P" "+Pl" || .#. "2P+" "Pl+" ?+ _ ]; 
 define 3pActor [ "+Indep" -> "+Indep" "+3P" "+Pl" || .#. "3P+" "Pl+" ?+ _ ]; 
+define ImpActor [ "+Indep" -> "+Indep" "+Imp" || .#. "Imp+" ?+ _ ]; 
 define PropagatePossessum [ 1sPossessum .o. 2sPossessum .o. 3sPossessum .o. 1pPossessum .o. 21Possessum .o. 2pPossessum .o. 3pPossessum ];
-define PropagateActor [ 1sActor .o. 2sActor .o. 3sActor .o. 3oActor .o. 1pActor .o. 21Actor .o. 2pActor .o. 3pActor ];
+define PropagateActor [ 1sActor .o. 2sActor .o. 3sActor .o. 3oActor .o. 1pActor .o. 21Actor .o. 2pActor .o. 3pActor .o. ImpActor ];
 define ObviativeAnimateOnly ~[$[ "+NI" ?* "+Obv" ]];
 define LongDistanceDependencies [ ObviativeAnimateOnly .o. InsertPossSg .o. InsertPossPl .o. InsertPossObv .o. InsertPossLoc .o. PropagatePossessum .o. PropagateActor .o. AnimatePlural .o. InanimatePlural .o. AnimateSingular .o. InanimateSingular ];
 define PossLinkingD [ "@" -> d || _ [ a | e | i \i ] ];  ! V 4.9.2, but not ii or oo as in 4.9.2.1


### PR DESCRIPTION
This corrects the handful of -dig suffixes per JP's email earlier tonight.  Also added rules for dropping a final short vowel in the 1st or 2nd person singular, Independent order:

$ echo "1P+Sg+zhooshkoboozo+Indep+Indic" | flookup -i nish.bin
1P+Sg+zhooshkoboozo+Indep+Indic n'zhooshǩbooz

$ echo "2P+Sg+zhooshkoboozo+Indep+Indic" | flookup -i nish.bin
2P+Sg+zhooshkoboozo+Indep+Indic gzhooshǩbooz
