### PR TITLE
First attempt at VAI2 verbs

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -99,7 +99,8 @@ niDep.txt: $(TSV)
 
 # want the FV stems (col 15) here, *not* column 6 with the -ng or -d ending...
 vai.txt: $(TSV)
-	cat $(TSV) | sed -n '/^\t[^\t]*\tvai\t/p' | cut -f 15 | egrep '[a-z]' | egrep -v ' ' | sed 's/^\///; s/-\/$$//' > $@
+	cat $(TSV) | sed -n '/^\t[^\t]*\tvai\tvai\t/p' | cut -f 15 | egrep '[a-z]' | egrep -v ' ' | sed 's/^\///; s/-\/$$//' > $@
+	cat $(TSV) | sed -n '/^\t[^\t]*\tvai\tvai2\t/p' | cut -f 15 | egrep '[a-z]' | egrep -v ' ' | sed 's/^\///; s/-\/$$//' | sed 's/$$/am/' >> $@
 
 classified-nouns.txt: naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt
 	cat naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt > $@

--- a/src/nish-template.txt
+++ b/src/nish-template.txt
@@ -178,29 +178,29 @@ LEXICON VAI_Nasal_Final_Indep_Suffixes
 	+2P+Sg+Indic:0		# ;
 	+3P+Sg+Indic:0		# ;
 	+3P+Obv+Indic:oon	# ;
-	+1P+Pl+Indic:omin		# ;
-	+1P+Ex+Indic:omin		# ;
-	+2P+Pl+Indic:om		# ;
+	+1P+Pl+Indic:~omin		# ;
+	+1P+Ex+Indic:~omin		# ;
+	+2P+Pl+Indic:~om		# ;
 	+3P+Pl+Indic:oog		# ;
-	+Imp+Indic:om		# ;
-	+1P+Sg+Pret:inaaban		# ;		! Biigtigong verb chart VAI sheet (2a)
-	+2P+Sg+Pret:inaaban		# ;
+	+Imp+Indic:~om		# ;
+	+1P+Sg+Pret:~inaaban		# ;		! Biigtigong verb chart VAI sheet (2a)
+	+2P+Sg+Pret:~inaaban		# ;
 	+3P+Sg+Pret:ooban		# ;
 	+3P+Obv+Pret:oobaniin		# ;
-	+1P+Pl+Pret:ominaaban		# ;
-	+1P+Ex+Pret:ominaaban		# ;
-	+2P+Pl+Pret:omwaaban		# ;
+	+1P+Pl+Pret:~ominaaban		# ;
+	+1P+Ex+Pret:~ominaaban		# ;
+	+2P+Pl+Pret:~omwaaban		# ;
 	+3P+Pl+Pret:oobaniig		# ;
-	+Imp+Pret:omwaaban			# ;
-	+1P+Sg+Dub:inaadog		# ;		! Biigtigong verb chart VAI sheet (3a)
-	+2P+Sg+Dub:inaadog		# ;
+	+Imp+Pret:~omwaaban			# ;
+	+1P+Sg+Dub:~inaadog		# ;		! Biigtigong verb chart VAI sheet (3a)
+	+2P+Sg+Dub:~inaadog		# ;
 	+3P+Sg+Dub:owidog		# ;
 	+3P+Obv+Dub:owidogwenan		# ;
-	+1P+Pl+Dub:iminaadog		# ;
-	+1P+Ex+Dub:iminaadog		# ;
-	+2P+Pl+Dub:imwaadog		# ;
+	+1P+Pl+Dub:~iminaadog		# ;
+	+1P+Ex+Dub:~iminaadog		# ;
+	+2P+Pl+Dub:~imwaadog		# ;
 	+3P+Pl+Dub:owidogwenag		# ;
-	+Imp+Dub:imwaadog			# ;
+	+Imp+Dub:~imwaadog			# ;
 	+3P+Sg+PretDub:amogoban		# ;		! Biigtigong verb chart VAI sheet (4a)
 	+3P+Obv+PretDub:aminigoban		# ;
 	+3P+Pl+PretDub:amogwaaban		# ;

--- a/src/nish.fst
+++ b/src/nish.fst
@@ -60,10 +60,12 @@ define PossThmRules [ n h "^" i m -> n y i m , w a "^" i m -> o m , a a "^" i m 
 define LeniteQuasiDim [ z e n s "^" i s -> z h e n z h i s ];  ! as in kwezens -> kwezhenzhish, gwiiwzens -> gwiiwzhenzhish, V p.193; do this before PejRules
 define SingularCleanup [ "^" [ w | W | y ] -> 0 || _ .#. ];
 define classVICleanup [ "^" A -> 0 ];
-define dropFinalCluster [ [ m | n ] "~" n -> n || [ a | e | i | o ] _ [ g | z ] ];
+define vai2Changes [ a m "~" [ i | o ] m -> a a m , a m "~" i n -> a a n , a m "~" b a n -> a m o b a n || \a _ ];
+define normalizeNasalToN [ [ m | n ] "~" n -> n || [ a | e | i | o ] _ [ g | z ] ];
+define adjustFinalNasal [ vai2Changes .o. normalizeNasalToN ];
 define keepFinalLongVowel [ "@" -> 0 || [ a a | i i | o o ] _ .#. ];
 define dropFinalShortVowel [ [ a | i | o ] "@" -> 0 || _ .#. ];
-define Cleanup [ "^" -> 0, "@" -> 0 ];
-define Morph [ DisallowIntermediateTags .o. LongDistanceDependencies .o. Lexicon .o. dropFinalCluster .o. keepFinalLongVowel .o. dropFinalShortVowel .o. PossPrefixRules .o. PluralRules .o. ClassVFinalI .o. ClassVOther .o. ConOrDimRules .o. ShortAConOrDim .o. LeniteQuasiDim .o. ClassVIDropY .o. PejRules .o. LocRules .o. PossThmRules .o. ShortALocOrPoss .o. classVICleanup .o. SingularCleanup .o. Cleanup .o. @"syncopate.bin" ];
+define Cleanup [ "~" -> 0, "^" -> 0, "@" -> 0 ];
+define Morph [ DisallowIntermediateTags .o. LongDistanceDependencies .o. Lexicon .o. adjustFinalNasal .o. keepFinalLongVowel .o. dropFinalShortVowel .o. PossPrefixRules .o. PluralRules .o. ClassVFinalI .o. ClassVOther .o. ConOrDimRules .o. ShortAConOrDim .o. LeniteQuasiDim .o. ClassVIDropY .o. PejRules .o. LocRules .o. PossThmRules .o. ShortALocOrPoss .o. classVICleanup .o. SingularCleanup .o. Cleanup .o. @"syncopate.bin" ];
 push Morph
 save stack nish.bin

--- a/src/nish.fst
+++ b/src/nish.fst
@@ -60,7 +60,7 @@ define PossThmRules [ n h "^" i m -> n y i m , w a "^" i m -> o m , a a "^" i m 
 define LeniteQuasiDim [ z e n s "^" i s -> z h e n z h i s ];  ! as in kwezens -> kwezhenzhish, gwiiwzens -> gwiiwzhenzhish, V p.193; do this before PejRules
 define SingularCleanup [ "^" [ w | W | y ] -> 0 || _ .#. ];
 define classVICleanup [ "^" A -> 0 ];
-define dropFinalCluster [ [ d | m | n | n d | t ] "~" n -> n || [ a | e | i | o ] _ [ g | z ] ];
+define dropFinalCluster [ [ m | n ] "~" n -> n || [ a | e | i | o ] _ [ g | z ] ];
 define keepFinalLongVowel [ "@" -> 0 || [ a a | i i | o o ] _ .#. ];
 define dropFinalShortVowel [ [ a | i | o ] "@" -> 0 || _ .#. ];
 define Cleanup [ "^" -> 0, "@" -> 0 ];


### PR DESCRIPTION
Easiest to treat final -am as part of stem; most endings behave like other nasal-final VAI's (-n or -aam), modulo a few changes (-am + om/in/im...).

src$ echo "1P+Ex+debwetam+Indep+Indic" | flookup -i nish.bin
1P+Ex+debwetam+Indep+Indic  gdebwetaamin
src$ echo "2P+Pl+debwetam+Indep+Indic" | flookup -i nish.bin
2P+Pl+debwetam+Indep+Indic  gdebwetaam
src$ echo "1P+Pl+debwetam+Indep+Pret" | flookup -i nish.bin
1P+Pl+debwetam+Indep+Pret   n'debwetaamnaaban
src$ echo "1P+Ex+debwetam+Indep+Pret" | flookup -i nish.bin
1P+Ex+debwetam+Indep+Pret   gdebwetaamnaaban
src$ echo "2P+Pl+debwetam+Indep+Pret" | flookup -i nish.bin
2P+Pl+debwetam+Indep+Pret   gdebwetaamwaaban
src$ echo "1P+Pl+biningwaam+Indep+Indic" | flookup -i nish.bin
1P+Pl+biningwaam+Indep+Indic    nbinngwaammin
src$ echo "1P+Ex+biningwaam+Indep+Indic" | flookup -i nish.bin
1P+Ex+biningwaam+Indep+Indic    gbinngwaammin
src$ echo "2P+Pl+biningwaam+Indep+Indic" | flookup -i nish.bin
2P+Pl+biningwaam+Indep+Indic    gbinngwaamom
src$ echo "1P+Pl+biningwaam+Indep+Pret" | flookup -i nish.bin
1P+Pl+biningwaam+Indep+Pret nbinngwaamminaaban
src$ echo "1P+Ex+biningwaam+Indep+Pret" | flookup -i nish.bin
1P+Ex+biningwaam+Indep+Pret gbinngwaamminaaban
src$ echo "2P+Pl+biningwaam+Indep+Pret" | flookup -i nish.bin
2P+Pl+biningwaam+Indep+Pret gbinngwaammwaaban
