### PR TITLE
don't allow singular inflection of VAIP

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -75,3 +75,5 @@ tsv-posswithm.txt
 tsv-singulars.txt
 tsv-syncopated.txt
 vai.txt
+vaio.txt
+vaip.txt

--- a/src/makefile
+++ b/src/makefile
@@ -105,10 +105,13 @@ vai.txt: $(TSV)
 vaio.txt: $(TSV)
 	cat $(TSV) | sed -n '/^\t[^\t]*\tvaio\t/p' | cut -f 15 | egrep '[a-z]' | egrep -v ' ' | sed 's/^\///; s/-\/$$//' > $@
 
+vaip.txt: $(TSV)
+	cat $(TSV) | sed -n '/^\t[^\t]*\tvaip\t/p' | cut -f 15 | egrep '[a-z]' | egrep -v ' ' | sed 's/^\///; s/-\/$$//' > $@
+
 classified-nouns.txt: naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt
 	cat naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt > $@
 
-nish.txt: nish-template.txt naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt vai.txt vaio.txt
+nish.txt: nish-template.txt naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.txt naIVa.txt niIVa.txt naIVb.txt naV.txt niV.txt naVI.txt niVI.txt naCon.txt niCon.txt naDim.txt niDim.txt naDep.txt niDep.txt vai.txt vaio.txt vaip.txt
 	rm -f templex.txt $@
 	cat naI.txt | sed 's/$$/\tNA_I ;/' > templex.txt
 	cat niI.txt | sed 's/$$/\tNI_I ;/' >> templex.txt
@@ -136,6 +139,9 @@ nish.txt: nish-template.txt naI.txt niI.txt naII.txt niII.txt naIII.txt niIII.tx
 	sed -i '/^LEXICON VAI_Stems/r templex.txt' $@
 	cat vaio.txt | sed 's/$$/\tVAIO_Suffixes ;/' > templex.txt
 	sed -i '/^LEXICON VAIO_Stems/r templex.txt' $@
+	cat vaip.txt | egrep '[aeio]$$' | sed 's/$$/\tVAIP_Vowel_Final_Suffixes ;/' > templex.txt
+	cat vaip.txt | egrep '[^aeio]$$' | sed 's/$$/\tVAIP_Nasal_Final_Suffixes ;/' >> templex.txt
+	sed -i '/^LEXICON VAIP_Stems/r templex.txt' $@
 	rm -f templex.txt
 	chmod 444 $@
 

--- a/src/nish-template.txt
+++ b/src/nish-template.txt
@@ -7,6 +7,7 @@ LEXICON Root
 LEXICON Verbs
 	VAI ;
 	VAIO ;
+	VAIP ;
 	! VII ;
 	! VTA ;
 	! VTI ;
@@ -16,6 +17,9 @@ LEXICON VAI
 
 LEXICON VAIO
 	VAIOSubjectPrefixes ;
+
+LEXICON VAIP
+	VAIPSubjectPrefixes ;
 
 LEXICON VAISubjectPrefixes
 	1P+Sg+:ni	VAI_Stems ;
@@ -28,6 +32,13 @@ LEXICON VAISubjectPrefixes
 	3P+Pl+:0	VAI_Stems ;
 	Imp+:0		VAI_Stems ;		! Impersonal ("unspecified actor")
 				VAI_Stems ;		! Conjunct order, actor propagated then stripped
+
+! need a separate trick to handle conjunct order
+LEXICON VAIPSubjectPrefixes
+	1P+Pl+:ni	VAIP_Stems ;
+	1P+Ex+:gi	VAIP_Stems ;
+	2P+Pl+:gi	VAIP_Stems ;
+	3P+Pl+:0	VAIP_Stems ;
 
 LEXICON VAIOSubjectPrefixes
 	1P+Sg+:ni	VAIO_Stems ;
@@ -44,6 +55,8 @@ LEXICON VAIOSubjectPrefixes
 LEXICON VAI_Stems
 
 LEXICON VAIO_Stems
+
+LEXICON VAIP_Stems
 
 LEXICON VAIO_Suffixes
 	+Indep:0		VAIO_Indep_Suffixes ;
@@ -491,6 +504,13 @@ LEXICON VAI_Vowel_Final_Suffixes
 	+Conj:0		VAI_Vowel_Final_Conj_Suffixes ;
 	! +CC:0		! changed conjuct verbal order
 
+! ok to use full VAI suffix table...
+! since we only accept plural actor prefixes under VAIPSubjectPrefixes above
+! none of the singular suffixes will apply
+! will need a separate trick to handle conjunct order...
+LEXICON VAIP_Vowel_Final_Suffixes
+	+Indep:0		VAI_Vowel_Final_Indep_Suffixes ;
+
 ! +Pres from Biigtigong tables implicit here 
 LEXICON VAI_Vowel_Final_Indep_Suffixes
 	+1P+Sg+Indic:@		# ;		! Biigtigong verb chart VAI sheet (1a)
@@ -631,6 +651,10 @@ LEXICON VAI_Vowel_Final_Conj_Suffixes
 LEXICON VAI_Nasal_Final_Suffixes
 	+Indep:0		VAI_Nasal_Final_Indep_Suffixes ;
 	+Conj:0		VAI_Nasal_Final_Conj_Suffixes ;
+
+! see comments above on VAIP_Vowel_Final_Suffixes
+LEXICON VAIP_Nasal_Final_Suffixes
+	+Indep:0		VAI_Nasal_Final_Indep_Suffixes ;
 
 LEXICON VAI_Nasal_Final_Indep_Suffixes
 	+1P+Sg+Indic:0		# ;		! Biigtigong verb chart VAI sheet (1a)


### PR DESCRIPTION
Only works for independent order right now...

src$ echo "1P+Sg+babaaminizhikodaadi+Indep+Neg+Indic" | flookup -i nish.bin
1P+Sg+babaaminizhikodaadi+Indep+Neg+Indic   +?

src$ echo "1P+Pl+babaaminizhikodaadi+Indep+Neg+Indic" | flookup -i nish.bin
1P+Pl+babaaminizhikodaadi+Indep+Neg+Indic   nbabaamnizhkodaadsiimin
