### PR TITLE
syncopation edge cases

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -10,7 +10,21 @@ all: badapost.txt badchar.txt badvowel.txt badcluster.txt
 	@echo "bad full-vowel clusters..."
 	@cat badcluster.txt
 
-comp: depsyncope-comparison.txt syncope-comparison.txt diminutive-comparison.txt locative-comparison.txt obviative-comparison.txt pejorative-comparison.txt possessive-comparison.txt posswithm-comparison.txt plural-comparison.txt singular-comparison.txt
+comp: syncope-comparison.txt diminutive-comparison.txt locative-comparison.txt obviative-comparison.txt pejorative-comparison.txt possessive-comparison.txt posswithm-comparison.txt plural-comparison.txt singular-comparison.txt
+
+#comp: depsyncope-comparison.txt syncope-comparison.txt diminutive-comparison.txt locative-comparison.txt obviative-comparison.txt pejorative-comparison.txt possessive-comparison.txt posswithm-comparison.txt plural-comparison.txt singular-comparison.txt
+
+fixcomp:
+	cp -f depsyncope-comparison-prev.txt depsyncope-comparison.txt
+	cp -f diminutive-comparison-prev.txt diminutive-comparison.txt
+	cp -f locative-comparison-prev.txt locative-comparison.txt
+	cp -f obviative-comparison-prev.txt obviative-comparison.txt
+	cp -f pejorative-comparison-prev.txt pejorative-comparison.txt
+	cp -f plural-comparison-prev.txt plural-comparison.txt
+	cp -f possessive-comparison-prev.txt possessive-comparison.txt
+	cp -f posswithm-comparison-prev.txt posswithm-comparison.txt
+	cp -f singular-comparison-prev.txt singular-comparison.txt
+	cp -f syncope-comparison-prev.txt syncope-comparison.txt
 
 gentest: FORCE
 	cat generation-test.txt | egrep -v '^#' > test-correct.txt
@@ -254,7 +268,7 @@ syncopated-test.txt: $(TSV) syncopate.bin
 	cat $(TSV) | egrep -v '^[a-z]' | cut -f 2,6 | egrep -v "^(we|wedi)[^ a-z]" | cut -f 2 | flookup -i syncopate.bin | egrep '.' | sed 's/^.*\t//' > $@
 
 depsyncopated-test.txt: $(TSV) nish.bin
-	cat $(TSV) | egrep '^[a-z]' | cut -f 3,6 | sed 's/^\(n[ai]\)p/\1/' | sed 's/^na\t\(.*\)/\1+NA+Sg/' | sed 's/^ni\t\(.*\)/\1+NI+Sg/' | sed "s/^/1P+Sg+Poss+/" | flookup -i nish.bin | egrep '.' | sed 's/^.*\t//' > $@
+	- cat $(TSV) | egrep '^[a-z]' | cut -f 3,6 | sed 's/^\(n[ai]\)p/\1/' | sed 's/^na\t\(.*\)/\1+NA+Sg/' | sed 's/^ni\t\(.*\)/\1+NI+Sg/' | sed "s/^/1P+Sg+Poss+/" | flookup -i nish.bin | egrep '.' | sed 's/^.*\t//' > $@
 
 singular-comparison.txt: singular-test.txt tsv-singulars.txt 
 	touch $@
@@ -280,7 +294,7 @@ locative-comparison.txt: locative-test.txt tsv-locatives.txt
 diminutive-comparison.txt: diminutive-test.txt tsv-diminutives.txt 
 	touch $@
 	mv -f $@ diminutive-comparison-prev.txt
-	paste diminutive-test.txt tsv-diminutives.txt | tolow | egrep -v '^(.+).\1$$' | egrep -v ' ' | egrep -v '^[^A-Za-z]' | egrep '[A-Za-z]$$' > $@
+	-paste diminutive-test.txt tsv-diminutives.txt | tolow | egrep -v '^(.+).\1$$' | egrep -v ' ' | egrep -v '^[^A-Za-z]' | egrep '[A-Za-z]$$' > $@
 	-diff -u diminutive-comparison-prev.txt $@
 	wc -l diminutive-comparison-prev.txt $@
 
@@ -326,7 +340,7 @@ depsyncope-comparison.txt: depsyncopated-test.txt tsv-depsyncopated.txt
 	mv -f $@ depsyncope-comparison-prev.txt
 	paste depsyncopated-test.txt tsv-depsyncopated.txt | tolow | egrep -v '^(.+).\1$$' | egrep -v ' ' | egrep -v '^[^A-Za-z]' > $@
 	-diff -u depsyncope-comparison-prev.txt $@
-	wc -l depsyncope-comparison-prev.txt $@
+	-wc -l depsyncope-comparison-prev.txt $@
 
 diacriticbug.txt: syncope-comparison.txt
 	cat syncope-comparison.txt | sed 's/ǧ/g/g; s/ȟ/h/g; s/ǩ/k/g' | egrep '^(.+)[^a-z]\1$$' | sed 's/\t.*//' > $@
@@ -359,3 +373,4 @@ distclean:
 	rm -f syncopate.bin nish.bin
 
 FORCE:
+

--- a/src/syncopate.fst
+++ b/src/syncopate.fst
@@ -10,8 +10,10 @@ define dropMarker [ F | L | X ];
 define Cons [ wAbleCons | otherCons ];
 define Cluster [ Cons | wAbleCons w ];
 define Hyphen [ "-" ];
+define insertShortAfterNH [ n h -> n h i || _ Cons ];
 define markWeak [ a -> F, i -> L, o -> X // .#. _ Cluster Vowel , .#. Cluster _ Cluster Vowel , Hyphen _ Cluster Vowel , Hyphen Cluster _ Cluster Vowel , LongV Cluster _ Cluster Vowel , dropMarker Cluster ShortV Cluster _ Cluster Vowel , dropMarker Cluster ShortV Cluster _ Hyphen , ? LongV Cluster _ Hyphen ];
 define insertApost [ c dropMarker h -> c ' h, m dropMarker b -> m ' b, n dropMarker d -> n ' d, n dropMarker g -> n ' g, n dropMarker h -> n ' h, n dropMarker j -> n ' j, n dropMarker s -> n ' s, n dropMarker y -> n ' y, n dropMarker z -> n ' z, s dropMarker h -> s ' h, s h dropMarker k -> s h ' k, s h dropMarker t -> s h ' t, s dropMarker k -> s ' k, s dropMarker p -> s ' p, z dropMarker h -> z ' h ];
+define dropWBeforeWeak [ w dropMarker -> 0 || wAbleCons _ ];
 define insertDiacriticsGK [ g X -> ǧ, k X -> ǩ, g w F -> ǧ, k w F -> ǩ || _ \w];
 define insertDiacriticsH [ h X -> ȟ, h w F -> ȟ || Vowel _ \w ];
 define initialO [ X -> w || .#. _, Hyphen _ ];
@@ -24,6 +26,6 @@ define fixZWY [ z w y -> z y ]; ! e.g. moozwayaanekizin -> moozyaanekzin
 define reflexiveException [ L -> i || n d _ w a a d .#. ];
 define dropAllMarkers [ F -> 0, L -> 0, X -> 0 ];
 define convertGlottal [ ' -> h ];
-define syncopate [ markWeak .o. convertGlottal .o. insertApost .o. insertDiacriticsGK .o. insertDiacriticsH .o. initialO .o. initialGwaKwa .o. reflexiveException .o. nonFinalNH .o. inflectionalWDeletionNonFinal .o. inflectionalWDeletion .o. fixFakeW .o. dropAllMarkers .o. fixZWY ];
+define syncopate [ insertShortAfterNH .o. markWeak .o. convertGlottal .o. insertApost .o. insertDiacriticsGK .o. insertDiacriticsH .o. dropWBeforeWeak .o. initialO .o. initialGwaKwa .o. reflexiveException .o. nonFinalNH .o. inflectionalWDeletionNonFinal .o. inflectionalWDeletion .o. fixFakeW .o. dropAllMarkers .o. fixZWY ];
 push defined syncopate
 save stack syncopate.bin


### PR DESCRIPTION
handles two issues; (1) I insert a "missing" short "i" into full vowel form before syncopation begins; cf. "bneshiinywayaan" and (2) I now drop "w" that appears before a dropped short vowel, cf. "jiibdinaag"
